### PR TITLE
Fix signature not being written to storage

### DIFF
--- a/src/Authentication/Storage/Jwt.php
+++ b/src/Authentication/Storage/Jwt.php
@@ -157,7 +157,7 @@ class Jwt implements StorageInterface
             $this->token = $this->jwt->createSignedToken(self::SESSION_CLAIM_NAME, $claim, $this->expirationSecs);
 
             $this->wrapped->write(
-                $this->token->getPayload()
+                $this->token->__toString()
             );
         } catch (\RuntimeException $e) {}
     }

--- a/test/Authentication/Storage/JwtTest.php
+++ b/test/Authentication/Storage/JwtTest.php
@@ -127,7 +127,7 @@ class JwtTest extends MockeryTestCase
             $newTokenValue = 'newtoken';
 
             $newToken = m::mock(Token::class);
-            $newToken->shouldReceive('getPayload')->andReturn($newTokenValue);
+            $newToken->shouldReceive('__toString')->andReturn($newTokenValue);
 
             $mockJwtService->shouldReceive('createSignedToken')->with('session-data', $written, 600)->andReturn($newToken);
             $mockStorage->shouldReceive('write')->with($newTokenValue)->once();


### PR DESCRIPTION
Signature wasn't being written to storage, so the only valid algorithm for tokens was 'none'.