### PR TITLE
Removed config duplication by using JWT expiry time for cookie expiry time

### DIFF
--- a/src/Authentication/Storage/CookieFactory.php
+++ b/src/Authentication/Storage/CookieFactory.php
@@ -15,6 +15,8 @@ class CookieFactory implements FactoryInterface
     {
         $config = $serviceLocator->get('Config')['jwt_zend_auth'];
 
+        $config['cookieOptions']['expiry'] = $config['expiry'];
+
         $cookieStorage = new Cookie(
             $serviceLocator->get('Request'),
             $config['cookieOptions']

--- a/src/Module.php
+++ b/src/Module.php
@@ -30,7 +30,6 @@ class Module implements ConfigProviderInterface
                     'path' => '/',
                     'domain' => null,
                     'secure' => true,
-                    'expiry' => 600,
                     'httpOnly' => true,
                 ],
                 'storage' => [


### PR DESCRIPTION
Allowing them to be different will cause some hard to debug issues for users